### PR TITLE
Customize ui

### DIFF
--- a/ime.json
+++ b/ime.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "guid": "{A381D463-9338-4FBD-B83D-66FFB03523B3}",
   "locale": "zh-TW",
+  "fallbackLocale": "zh-TW",
   "icon": "icon.ico",
   "win8_icon": "",
   "moduleName": "index",

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  candPerRow: 3
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 
 let emojione = require('emojione');
 let debug    = require('debug')('nime:emojime');
+let config = require('./config');
 
 let {
   reduceOnKeyDown,
@@ -40,11 +41,14 @@ module.exports = {
   },
 
   response(request, state) {
+    let res = {success: true, seqNum: request['seqNum']};
     if (request['method'] === 'filterKeyDown') {
       return respOnFilterKeyDown(request, state);
 
     } else if (request['method'] === 'onKeyDown') {
       return respOnKeyDown(request, state);
+    } else if (request['method'] === 'onActivate') {
+      return Object.assign({}, res, { customizeUI: { candPerRow: config.candPerRow, candUseCursor: true }})
     }
     return {success: true, seqNum: request['seqNum']};
   }

--- a/src/reducer/candidateMode.js
+++ b/src/reducer/candidateMode.js
@@ -2,6 +2,7 @@
 
 let debug    = require('debug')('nime:emojime:composition');
 let KEYCODE  = require('nime/lib/keyCodes');
+let config = require('../config');
 
 function candidateMode(request, preState) {
 
@@ -23,7 +24,7 @@ function candidateMode(request, preState) {
   }
 
   if (keyCode === KEYCODE.VK_DOWN) {
-    candidateCursor = (candidateCursor + 3) % candidateList.length;
+    candidateCursor = (candidateCursor + config.candPerRow) % candidateList.length;
     return Object.assign({}, preState, {
       action: 'UPDATE_CANDIDATE',
       candidateCursor
@@ -31,7 +32,7 @@ function candidateMode(request, preState) {
   }
 
   if (keyCode === KEYCODE.VK_UP) {
-    candidateCursor = candidateCursor < 3 ? 0 : candidateCursor - 3;
+    candidateCursor = candidateCursor < config.candPerRow ? 0 : candidateCursor - config.candPerRow;
     return Object.assign({}, preState, {
       action: 'UPDATE_CANDIDATE',
       candidateCursor


### PR DESCRIPTION
* add customizeUI to prevent candidate cursor missing.
* add fallbackLocale so when the new RFC 4646 locale name is not recognized by Windows, we can fallback to the old RFC 1766 format.